### PR TITLE
Add support for Qt 6.5.3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,14 +45,14 @@ project(squintymongrel LANGUAGES CXX)
 
 # note that find_package() populates the package_VERSION variable, as well as packagecomponent_VERSION variable.
 # this can be used for further checks as below.
-find_package(Qt NAMES Qt5 COMPONENTS Core REQUIRED)
-find_package(Qt5 COMPONENTS Core Gui Widgets WebEngineWidgets WebChannel REQUIRED)
+find_package(Qt NAMES Qt5 Qt6 COMPONENTS Core REQUIRED)
+find_package(Qt${Qt_VERSION_MAJOR} COMPONENTS Core Gui Widgets WebEngineWidgets WebChannel REQUIRED)
 # package_VERSION
 message("Qt Version: " ${Qt_VERSION})
-# message("Qt5 Version: " ${Qt5_VERSION})
+# message("Qt6 Version: " ${Qt6_VERSION})
 # packagecomponent_VERSION
-# message("Qt5Core Version: " ${Qt5Core_VERSION})
-# message("Qt5Widgets Version: " ${Qt5Widgets_VERSION})
+# message("Qt6Core Version: " ${Qt6Core_VERSION})
+# message("Qt6Widgets Version: " ${Qt6Widgets_VERSION})
 
 
 # https://itecnote.com/tecnote/qt-test-for-supported-qt-version-with-cmake/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,10 +49,10 @@ find_package(Qt NAMES Qt5 Qt6 COMPONENTS Core REQUIRED)
 find_package(Qt${Qt_VERSION_MAJOR} COMPONENTS Core Gui Widgets WebEngineWidgets WebChannel REQUIRED)
 # package_VERSION
 message("Qt Version: " ${Qt_VERSION})
-# message("Qt6 Version: " ${Qt6_VERSION})
+# message("Qt${Qt_VERSION_MAJOR} Version: " ${Qt${Qt_VERSION_MAJOR}_VERSION})
 # packagecomponent_VERSION
-# message("Qt6Core Version: " ${Qt6Core_VERSION})
-# message("Qt6Widgets Version: " ${Qt6Widgets_VERSION})
+# message("Qt${Qt_VERSION_MAJOR}Core Version: " ${Qt${Qt_VERSION_MAJOR}Core_VERSION})
+# message("Qt${Qt_VERSION_MAJOR}Widgets Version: " ${Qt${Qt_VERSION_MAJOR}Widgets_VERSION})
 
 
 # https://itecnote.com/tecnote/qt-test-for-supported-qt-version-with-cmake/

--- a/Makefile
+++ b/Makefile
@@ -158,7 +158,14 @@ dummy:
 
 # examples:
 # make distclean
-# make -j$(nproc) 2>&1 | tee build_default.log
-# make -j$(nproc) QMAKE_PATH=/usr/lib/x86_64-linux-gnu/qt5/bin/qmake 2>&1 | tee build_5_12_8.log
-# make -j$(nproc) QMAKE_PATH=/home/${USER}/qt/5.15.2/gcc_64/bin/qmake 2>&1 | tee build_5_15_2.log
-
+# build : make -j$(nproc) 2>&1 | tee build_default.log
+# run   : ./install/bin/squintymongrel
+#
+# build : make -j$(nproc) QMAKE_PATH=/usr/lib/x86_64-linux-gnu/qt5/bin/qmake 2>&1 | tee build_5_12_8.log
+# run   : LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu/qt5/lib:${LD_LIBRARY_PATH} ./install/bin/squintymongrel
+#
+# build : make -j$(nproc) QMAKE_PATH=/home/${USER}/qt/5.15.2/gcc_64/bin/qmake 2>&1 | tee build_5_15_2.log
+# run   : LD_LIBRARY_PATH=/home/${USER}/qt/5.15.2/gcc_64/lib:${LD_LIBRARY_PATH} ./install/bin/squintymongrel
+#
+# build : make -j$(nproc) QMAKE_PATH=/home/${USER}/qt/6.5.3/gcc_64/bin/qmake 2>&1 | tee build_6_5_3.log
+# run   : LD_LIBRARY_PATH=/home/${USER}/qt/6.5.3/gcc_64/lib:${LD_LIBRARY_PATH} ./install/bin/squintymongrel

--- a/README.md
+++ b/README.md
@@ -13,8 +13,9 @@ ADD MORE!
 ### Platforms
 
 Tested on Ubuntu 20.04 with:
-- default `apt` provided `Qt 5.12.8`
-- Qt Installer provided `Qt 5.15.2` ( base install path used: `/home/${USER}/qt` ==>> so, `5.15.2` path: `/home/${USER}/qt/5.15.2` )
+- `Qt 5.12.8` installed using `apt` (default version for Ubuntu 20.04)
+- `Qt 5.15.2` installed using Qt Installer ( base install path used: `/home/${USER}/qt` ==>> so, `5.15.2` path: `/home/${USER}/qt/5.15.2` )
+- `Qt 6.5.3` installed using Qt Installer ( base install path used: `/home/${USER}/qt` ==>> so, `6.5.3` path: `/home/${USER}/qt/6.5.3` )
 
 In general, it is recommended to use a base path like: `/home/${USER}/qt` or `/opt/qt` for installation, so it becomes easy to use the same build commands across different machines.
 
@@ -59,6 +60,14 @@ If we want to use a separate non-distro-provided installation of Qt, using a Qt 
    make QMAKE_PATH=/home/${USER}/qt/5.15.2/gcc_64/bin/qmake
    ```
 
+   For example, if we have `Qt 6.5.3` installation at: `/home/${USER}/qt/6.5.3`  
+   Then, qmake path for gcc, x86_64 will be at: `/home/${USER}/qt/6.5.3/gcc_64/bin/qmake`  
+   and then we use:  
+   ```bash
+   make QMAKE_PATH=/home/${USER}/qt/6.5.3/gcc_64/bin/qmake
+   ```
+
+
 
 ### Run Local Install
 
@@ -82,6 +91,12 @@ and then we use:
 LD_LIBRARY_PATH=/home/${USER}/qt/5.15.2/gcc_64/lib:$LD_LIBRARY_PATH ./install/bin/squintymongrel
 ```
 
+For example, if we have `Qt 6.5.3` installation at: `/home/${USER}/qt/6.5.3`  
+Then, lib path for gcc, x86_64 will be at: `/home/${USER}/qt/6.5.3/gcc_64/lib`  
+and then we use:  
+```bash
+LD_LIBRARY_PATH=/home/${USER}/qt/6.5.3/gcc_64/lib:$LD_LIBRARY_PATH ./install/bin/squintymongrel
+```
 
 ## Attributions
 

--- a/resources/monaco-editor.html
+++ b/resources/monaco-editor.html
@@ -186,13 +186,30 @@
       window.cppEndPoint = channel.objects.CPPEndPoint;
       window.cppEndPoint.log("QWebChannel created!");
 
+      // read the 'intValue' exposed as a 'property' (this is an int)
       // alert("we got intValue: " + window.cppEndPoint.intValue);
       window.cppEndPoint.log("we got intValue: " + window.cppEndPoint.intValue);
 
+      // read the 'qtVersion' exposed as a 'property' (this is a list of ints)
+      //alert("we got qtVersion: " + window.cppEndPoint.qtVersion);
+      var qtVersion = window.cppEndPoint.qtVersion;
+      window.cppEndPoint.log("we got qtVersion: " + qtVersion[0] + "." + qtVersion[1] + "." + qtVersion[2]);
+
+      // connect the Qt side updateFilePath(QString filepath) signal to anon function, and handle it:
       window.cppEndPoint.updateFilePath.connect(function(path) {
         // alert(path);
-        readFileFromPathUsingXHR(path);
-        // readFileFromPathUsingFetch(path); // -> won't work as: Fetch API cannot load ... URL scheme "file" is not supported.
+
+        // FUTURE: use semver JS library (https://stackoverflow.com/a/30256597/3379867)
+        if(window.cppEndPoint.qtVersion[0] >= 6 &&
+           window.cppEndPoint.qtVersion[1] >= 5 &&
+           window.cppEndPoint.qtVersion[2] >= 3) {
+            // Qt 6.5.3 seems to be support FETCH API, so use that
+            readFileFromPathUsingFetch(path);
+           }
+        else {
+          // Older Qt versions refuse to allow FETCH API with a 'file:///' URL so use XMLHTTPRequest
+          readFileFromPathUsingXHR(path);
+        }
       })
     });
   </script>

--- a/src/cpp_endpoint.cpp
+++ b/src/cpp_endpoint.cpp
@@ -14,6 +14,16 @@
 #define STRINGIFY(x) #x
 
 
+CPPEndPoint::CPPEndPoint(QObject* parent) {
+  
+  // set the Qt Version property:
+  m_qtVersion.append(((QT_VERSION) >> 16) & 0xff);
+  m_qtVersion.append(((QT_VERSION) >> 8) & 0xff);
+  m_qtVersion.append((QT_VERSION) & 0xff);
+
+}
+
+
 Q_INVOKABLE void CPPEndPoint::log(QVariant s)
 {
   QString str = s.toString();
@@ -35,4 +45,12 @@ Q_INVOKABLE int CPPEndPoint::getIntValue()
 {
   qDebug() << "getIntValue()";
   return m_intValue;
+}
+
+
+Q_INVOKABLE QVariant CPPEndPoint::getQtVersion()
+{
+  QVariant variant = QVariant::fromValue(m_qtVersion);
+  qDebug() << "getQtVersion()";
+  return variant;
 }

--- a/src/cpp_endpoint.h
+++ b/src/cpp_endpoint.h
@@ -13,7 +13,7 @@ class CPPEndPoint: public QObject
     Q_OBJECT
 
 public:
-    CPPEndPoint(QObject* parent=nullptr) {}
+    CPPEndPoint(QObject* parent=nullptr);
 
 
 public:
@@ -24,6 +24,10 @@ public:
     Q_PROPERTY(int intValue READ getIntValue NOTIFY intValueChanged);
     Q_INVOKABLE int getIntValue();
 
+    // expose 'qtVersion' as a property, which will invoke getQtVersion() to get the value
+    Q_PROPERTY(QVariant qtVersion READ getQtVersion CONSTANT);
+    Q_INVOKABLE QVariant getQtVersion();
+
 
 signals:
     void intValueChanged(int);
@@ -32,6 +36,7 @@ signals:
 
 private:
     int m_intValue = 413;
+    QList<int> m_qtVersion;
 };
 
 #endif // #ifndef CPP_ENDPOINT_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -64,11 +64,14 @@ int main(int argc, char *argv[])
     qDebug() << "";
 
 
+#if (QT_VERSION < QT_VERSION_CHECK(6, 5, 3))
     // https://doc.qt.io/qt-5/highdpi.html
     QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
     // Qt5 only: Make QIcon::pixmap() generate high-dpi pixmaps that can be larger than the requested size.
     QCoreApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
-
+#else
+    // the Qt::AA_EnableHighDpiScaling and Qt::AA_UseHighDpiPixmaps are always enabled in Qt6 and deprecated.
+#endif
 
     // https://stackoverflow.com/questions/64892161/qtwebengine-fetch-api-fails-with-custom-scheme ( Qt 6.6 though :-( )
     // https://doc.qt.io/qt-5/qtwebengine-debugging.html

--- a/src/monaco_text_editor.cpp
+++ b/src/monaco_text_editor.cpp
@@ -128,8 +128,18 @@ MonacoTextEditor::~MonacoTextEditor() {
 
 }
 
+
 void MonacoTextEditor::openFileInCurrentTab(QString filepath) {
 
   emit CPPEndPointObject->updateFilePath(filepath);
+
+}
+
+
+void MonacoTextEditor::runJavaScript(QString javascriptCode) {
+
+  if(webEngineView->page()) {
+    webEngineView->page()->runJavaScript(javascriptCode);
+  }
 
 }

--- a/src/monaco_text_editor.h
+++ b/src/monaco_text_editor.h
@@ -20,6 +20,7 @@ public:
     ~MonacoTextEditor();
 
     void openFileInCurrentTab(QString filepath);
+    void runJavaScript(QString javascriptCode);
 
 
 private:

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -230,8 +230,10 @@ void Window::onFileExplorerDoubleClicked(const QModelIndex& modelIndex) {
     QString filepath = model->filePath(modelIndex);
     
     qDebug() << "double-clicked on: " << filepath;
-    
-    textEditor->openFileInCurrentTab(filepath);
+
+    if(QFileInfo(filepath).isFile()) {
+        textEditor->openFileInCurrentTab(filepath);
+    }
 }
 
 


### PR DESCRIPTION
- Qt 6.5.3 works mostly as is with the code, a few deprecations are now within `#ifdef`s
- Ensure CMakeLists.txt is updated to work with either Qt5 or Qt6
- Added a `qtVersion` property that can be read from JS and use it
- JavaScript code in Monaco Editor HTML updated to use `FETCH` API for Qt6, as it is supported now, and switch to the XHR style for Qt5 as before
- Bug Fix: on double-click open only if it is a file.